### PR TITLE
Rename CR identifier to avoid collisions with ARM64 structs in winnt.h

### DIFF
--- a/zip30/revision.h
+++ b/zip30/revision.h
@@ -21,8 +21,8 @@
 #define Z_PATCHLEVEL 0
 #define Z_BETALEVEL "i BETA"
 
-#define VERSION "3.0"
-#define REVDATE "July 5th 2008"
+#define VERSION "3.0-ioERes"
+#define REVDATE "2021-12-17.01"
 
 #define DW_MAJORVER    Z_MAJORVER
 #define DW_MINORVER    Z_MINORVER
@@ -58,7 +58,7 @@ ZCONST char *copyright[] = {
 };
 
 ZCONST char * far versinfolines[] = {
-"This is %s %s (%s), by Info-ZIP.",
+"This is %s %s (%s), by Info-ZIP with changes by Saint Wesonga.",
 "Currently maintained by E. Gordon.  Please send bug reports to",
 "the authors using the web page at www.info-zip.org; see README for details.",
 "",

--- a/zip30/win32/makefile.w32
+++ b/zip30/win32/makefile.w32
@@ -92,7 +92,7 @@ RC=rc
 # by passing the -stub switch to the 32-bit linker to specify the 16-bit part.
 
 LD=link -nologo
-LDFLAGS=user32.lib advapi32.lib /OPT:NOWIN98 /INCREMENTAL:NO /PDB:$*.pdb $(EXTLIB)
+LDFLAGS=user32.lib advapi32.lib /INCREMENTAL:NO /PDB:$*.pdb $(EXTLIB)
 SYMS=/DEBUG:full /DEBUGTYPE:CV
 !IFDEF debug
 LDFLAGS=$(LDFLAGS) $(SYMS)

--- a/zip30/zip.h
+++ b/zip30/zip.h
@@ -262,7 +262,7 @@ struct plist {
 
 /* ASCII definitions for line terminators in text files: */
 #define LF     10        /* '\n' on ASCII machines; must be 10 due to EBCDIC */
-#define CR     13        /* '\r' on ASCII machines; must be 13 due to EBCDIC */
+#define CARRIAGE_RETURN 13        /* '\r' on ASCII machines; must be 13 due to EBCDIC */
 #define CTRLZ  26        /* DOS & OS/2 EOF marker (used in fileio.c, vms.c) */
 
 /* return codes of password fetches (negative: user abort; positive: error) */

--- a/zip30/zipup.c
+++ b/zip30/zipup.c
@@ -1217,7 +1217,7 @@ local unsigned file_read(buf, size)
 #endif /* EBCDIC */
       {
          do {
-            if ((*buf++ = *b++) == '\n') *(buf-1) = CR, *buf++ = LF, len++;
+            if ((*buf++ = *b++) == '\n') *(buf-1) = CARRIAGE_RETURN, *buf++ = LF, len++;
          } while (--size != 0);
       }
       buf -= len;
@@ -1257,7 +1257,7 @@ local unsigned file_read(buf, size)
 #endif /* EBCDIC */
       {
          do {
-            if (( *buf++ = *b++) == CR && *b == LF) buf--, len--;
+            if (( *buf++ = *b++) == CARRIAGE_RETURN && *b == LF) buf--, len--;
          } while (--size != 0);
       }
       if (len == 0) {


### PR DESCRIPTION
The IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY struct has a bitfield named CR. The #define CR directive therefore results in invalid C code. This PR renames that identifier.

This PR also updates the version and revision date to indicate that it is not the official Info-ZIP source and removes the /OPT:NOWIN98 flag (which was removed in VS 2010). See https://docs.microsoft.com/en-us/cpp/porting/visual-cpp-change-history-2003-2015?view=msvc-170#visual-studio-2010-breaking-changes