### PR TITLE
Fix macOS clang compile errors

### DIFF
--- a/zip30/unix/configure
+++ b/zip30/unix/configure
@@ -519,7 +519,10 @@ done
 
 
 echo Check for memset
-echo "int main(){ char k; memset(&k,0,0); return 0; }" > conftest.c
+cat > conftest.c << _EOF_
+#include <string.h>
+int main(){ char k; memset(&k,0,0); return 0; }
+_EOF_
 $CC -o conftest conftest.c >/dev/null 2>/dev/null
 [ $? -ne 0 ] && CFLAGS="${CFLAGS} -DZMEM"
 

--- a/zip30/unix/unix.c
+++ b/zip30/unix/unix.c
@@ -67,7 +67,6 @@ local char *readd OF((DIR *));
 #ifndef dirent
 #  define dirent direct
 #endif
-typedef FILE DIR;
 /*
 **  Apparently originally by Rich Salz.
 **  Cleaned up and modified by James W. Birdsall.


### PR DESCRIPTION
Fixes #32 by removing the -DZMEM flag that was causing library functions to be redefined