### PR TITLE
Change the default number of retries to 5

### DIFF
--- a/zip30/globals.c
+++ b/zip30/globals.c
@@ -161,7 +161,7 @@ ulg after = 0;          /* 0=ignore, else exclude files newer than this time */
 char *zipfile;          /* New or existing zip archive (zip file) */
 
 /* I/O retry options */
-int max_retries = 0;     /* Max number of file I/O operation retries */
+int max_retries = 5;     /* Max number of file I/O operation retries */
 time_t retry_delay = 30; /* Seconds before retrying a file I/O operation */
 
 /* zip64 support 08/31/2003 R.Nausedat */

--- a/zip30/revision.h
+++ b/zip30/revision.h
@@ -22,7 +22,7 @@
 #define Z_BETALEVEL "i BETA"
 
 #define VERSION "3.0-ioERes"
-#define REVDATE "2021-12-27.02"
+#define REVDATE "2022-01-04.01"
 
 #define DW_MAJORVER    Z_MAJORVER
 #define DW_MINORVER    Z_MINORVER

--- a/zip30/zip.c
+++ b/zip30/zip.c
@@ -2197,7 +2197,7 @@ char **argv;            /* command line tokens */
 #endif
 
   char **args = NULL;  /* could be wide argv */
-  max_retries = 0;
+  max_retries = 5;
   retry_delay = 30;
 
 


### PR DESCRIPTION
A default of 0 means that every caller of the zip binary has to manually specify a non-zero number of retries. For example, building different JDK repos would need separate changes to each [make/common/ZipArchive.gmk](https://github.com/openjdk/jdk/blob/master/make/common/ZipArchive.gmk#L172) file. The whole point of retry-zip is to avoid having to intervene for issues that can be resolved by retrying after a small delay. This change avoids having to manually specify the retries, which would detract from that goal. 